### PR TITLE
Update dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,8 +26,8 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "1.3.x",
-    "angular-sanitize": "1.3.x"
+    "angular": "^1.3",
+    "angular-sanitize": "^1.3"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "smileys"
   ],
   "dependencies": {
-    "angular": "1.3.x",
-    "angular-sanitize": "1.3.x"
+    "angular": "^1.3",
+    "angular-sanitize": "^1.3"
   },
   "bugs": {
     "url": "https://github.com/ritz078/ngEmoticons/issues"


### PR DESCRIPTION
This PR allows compatibility with Angular versions outside of the 1.3 line, fixing these types of errors:

```
npm WARN deprecated angular-sanitize@1.3.36: bad package, use v1.3.5 instead
npm WARN deprecated angular@1.3.36: bad package, use v1.3.5 instead
```

Also fixes #7 
